### PR TITLE
feat: add context menu and synced flag

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -33,6 +33,6 @@ export default defineManifest({
       js: ['src/content/index.tsx']
     }
   ],
-  permissions: ['sidePanel', 'storage'],
+  permissions: ['sidePanel', 'storage', 'contextMenus'],
   host_permissions: ['https://chatgpt.com/*', 'https://www.chatgpt.com/*']
 } as any);

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -11,6 +11,7 @@ interface QueueTask {
   result?: string;
   error?: string;
   messages: Message[];
+  synced: boolean;
 }
 
 const taskQueue: QueueTask[] = [];
@@ -124,6 +125,41 @@ chrome.action.onClicked.addListener((tab) => {
   }
 });
 
+// 创建右键菜单，仅在指定域名下显示
+const allowedHosts = ['chatgpt.com', 'www.chatgpt.com'];
+chrome.runtime.onInstalled.addListener(() => {
+  const documentUrlPatterns = allowedHosts.map(host => `*://${host}/*`);
+  chrome.contextMenus.create({
+    id: 'save_to_notion',
+    title: 'Save to Notion',
+    contexts: ['all'],
+    documentUrlPatterns,
+  });
+  chrome.contextMenus.create({
+    id: 'save_directly',
+    parentId: 'save_to_notion',
+    title: 'Save directly',
+    contexts: ['all'],
+    documentUrlPatterns,
+  });
+  chrome.contextMenus.create({
+    id: 'generate_post',
+    parentId: 'save_to_notion',
+    title: 'Generate Post',
+    contexts: ['all'],
+    documentUrlPatterns,
+  });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => {
+  if (!tab || typeof tab.id === 'undefined') return;
+  if (info.menuItemId === 'generate_post') {
+    chrome.tabs.sendMessage(tab.id, { type: 'saveToNotion', action: 'generate' });
+  } else if (info.menuItemId === 'save_directly') {
+    chrome.tabs.sendMessage(tab.id, { type: 'saveToNotion', action: 'direct' });
+  }
+});
+
 chrome.runtime.onMessage.addListener(async (
   message: any,
   sender: chrome.runtime.MessageSender,
@@ -160,7 +196,8 @@ chrome.runtime.onMessage.addListener(async (
       domain,
       model: current.model || '',
       status: 'pending',
-      messages
+      messages,
+      synced: false,
     };
     taskQueue.push(task);
     taskState.pending.push(task);

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,105 +1,29 @@
-import React, { useEffect } from 'react';
-import { createRoot } from 'react-dom/client';
 import { ChatGptCollector } from './ChatgptCollector';
 import { logger } from '@/lib/logger';
 
-// Minimal content script UI mounted via Shadow DOM to avoid site CSS conflicts
-const hostId = 'vite-react-ts-extension-content-root';
-
-// 仅在允许的域名上注入（例如：https://chatgpt.com/）
+// Domains where the content script should respond
 const allowedHosts = ['chatgpt.com', 'www.chatgpt.com'];
 
-// mount 函数负责创建 Shadow DOM 宿主元素，将样式注入其中，并挂载 React 应用程序。
-// 它确保内容脚本的 UI 在页面上是隔离的，避免与现有页面样式和脚本冲突。
-function mount(domain: string) {
-  console.log('[content] mounting on domain:', domain);
-
-  if (document.getElementById(hostId)) return;
-
-  const host = document.createElement('div');
-  host.id = hostId;
-  const shadow = host.attachShadow({ mode: 'open' });
-
-  const mountPoint = document.createElement('div');
-  shadow.appendChild(mountPoint);
-
-  // Optional: inject minimal styles scoped to shadow root
-  const style = document.createElement('style');
-  style.textContent = `
-    .__badge {
-      position: fixed;
-      z-index: 2147483647;
-      right: 12px;
-      bottom: 12px;
-      background: #2563eb;
-      color: #fff;
-      font: 12px/1.2 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
-      padding: 6px 8px;
-      border-radius: 6px;
-      box-shadow: 0 4px 12px rgba(0,0,0,.15);
-      cursor: pointer;
-      opacity: .9;
-    }
-    .__badge:hover { opacity: 1; }
-  `;
-  shadow.appendChild(style);
-
-  document.documentElement.appendChild(host);
-
-  // App 组件是一个简单的 React 函数组件，它渲染一个可点击的徽章。
-  // 点击徽章会向扩展的后台脚本发送一条消息。
-  const ExecutionButton = () => {
-    useEffect(() => {
-      const listener = (message: any) => {
-        if (message?.type === 'queueProgress') {
-          alert(String(message.payload?.status || '')); 
-        }
-      };
-      chrome.runtime.onMessage.addListener(listener);
-      return () => chrome.runtime.onMessage.removeListener(listener);
-    }, []);
-
-    const loadingCurrentMessages = () => {
-      // 取得地址栏url最后一个斜杠“/”之后的字符串
+if (allowedHosts.includes(location.hostname)) {
+  // Listen for messages from the background script triggered by context menu
+  chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+    if (message?.type === 'saveToNotion') {
       const taskId = window.location.href.replace(/\/$/, '').split('/').pop();
       const messages = new ChatGptCollector().getAllMessages();
       logger.content.info('Collected messages', messages);
+
       chrome.runtime.sendMessage({
         type: 'queueGenerate',
-        payload: { domain, messages, taskId, action: 'generate' }
+        payload: {
+          domain: location.hostname,
+          messages,
+          taskId,
+          action: message.action || 'generate',
+        },
       });
       alert('Task added to queue');
-    };
-
-    return (
-      <div className="__badge" onClick={loadingCurrentMessages}>
-        Generate Post
-      </div>
-    );
-  };
-
-  const root = createRoot(mountPoint);
-  root.render(<ExecutionButton />);
-}
-
-try {
-  // 仅当访问允许的域名时才注入按钮
-  const isAllowed = allowedHosts.includes(location.hostname);
-  if (!isAllowed) {
-    console.log('[content] skipped - domain not allowed:', location.hostname);
-  } else {
-    mount(location.hostname);
-    // HMR friendly: re-mount on updates
-    if (import.meta.hot) {
-      import.meta.hot.accept(() => {
-        const existing = document.getElementById(hostId);
-        if (existing) existing.remove();
-        mount(location.hostname);
-        console.log('[content] HMR update applied');
-      });
+      sendResponse({ ok: true });
     }
-    console.log('[content] injected');
-  }
-} catch (e) {
-  // ignore
+  });
 }
+

--- a/src/pages/sidepanel/ResultItem.tsx
+++ b/src/pages/sidepanel/ResultItem.tsx
@@ -19,7 +19,10 @@ const ResultItem: React.FC<ResultItemProps> = ({
   onDelete,
 }) => {
   return (
-    <li className="border rounded-lg p-4 space-y-2 bg-white dark:bg-gray-800 shadow-sm hover:shadow transition-shadow">
+    <li className="relative border rounded-lg p-4 space-y-2 bg-white dark:bg-gray-800 shadow-sm hover:shadow transition-shadow">
+      {task.synced && (
+        <span className="absolute top-1 right-1 w-2 h-2 bg-green-500 rounded-full"></span>
+      )}
       <div className="flex justify-between items-start">
         <div className="flex-1">
           <div className="text-xs text-gray-500">

--- a/src/pages/sidepanel/main.tsx
+++ b/src/pages/sidepanel/main.tsx
@@ -155,7 +155,8 @@ function hello() {
 
 ## 内联代码
 
-使用 \`npm install\` 命令安装依赖。`
+使用 \`npm install\` 命令安装依赖。`,
+            synced: false,
           },
           {
             id: 'sample-2',
@@ -188,7 +189,8 @@ sequenceDiagram
     B->>A: 显示结果
 \`\`\`
 
-这是一个包含 Mermaid 图表的示例任务。`
+这是一个包含 Mermaid 图表的示例任务。`,
+            synced: false,
           }
         ];
         setTasks(sampleTasks);

--- a/src/type/global.d.ts
+++ b/src/type/global.d.ts
@@ -15,4 +15,5 @@ interface Task {
   status: string;
   result: string;
   model?: string;
+  synced: boolean;
 }


### PR DESCRIPTION
## Summary
- trigger save actions from a context menu instead of an injected button
- add `synced` flag to queue tasks and show synced marker in sidepanel
- only display context menu on chatgpt.com domains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6ce53aab08331a327a36973b38830